### PR TITLE
chore(quality): apply RUST.MD and AGENTS.md compliance

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,8 @@
+# markdownlint configuration
+# Line length relaxed for tables and long URLs
+MD013:
+  line_length: 120
+  tables: false
+  code_blocks: false
+# Allow inline HTML for badges
+MD033: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,14 @@ tower = { version = "0.5", features = ["util"] }
 [[bench]]
 name = "gateway_bench"
 harness = false
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+unwrap_used = "warn"
+expect_used = "warn"
+panic = "warn"
+# Allow common pedantic patterns in existing codebase
+module_name_repetitions = "allow"
+must_use_candidate = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -12,11 +12,13 @@ This document contains performance test results for RustyGW API Gateway.
 ## Benchmark Results
 
 ### Moderate Load Test
+
 ```bash
 wrk -t4 -c100 -d30s http://localhost:8094/metrics
 ```
 
 **Results:**
+
 - **RPS**: 21,989 requests/sec
 - **Latency Average**: 4.59ms
 - **Latency Max**: 41.64ms
@@ -24,11 +26,13 @@ wrk -t4 -c100 -d30s http://localhost:8094/metrics
 - **Total Requests**: 660,057 in 30s
 
 ### Extreme Load Test
+
 ```bash
 wrk -t8 -c200 -d60s http://localhost:8094/metrics
 ```
 
 **Results:**
+
 - **RPS**: 20,550 requests/sec
 - **Latency Average**: 9.90ms
 - **Latency Max**: 65.83ms
@@ -37,31 +41,31 @@ wrk -t8 -c200 -d60s http://localhost:8094/metrics
 
 ## Performance Summary
 
-| Metric | Moderate Load | Extreme Load |
-|--------|---------------|--------------|
+| Metric | Moderate | Extreme |
+| --- | --- | --- |
 | Threads | 4 | 8 |
 | Connections | 100 | 200 |
 | Duration | 30s | 60s |
-| **RPS** | **21,989** | **20,550** |
-| **Avg Latency** | **4.59ms** | **9.90ms** |
-| **Max Latency** | **41.64ms** | **65.83ms** |
-| **Throughput** | **71.88MB/s** | **67.42MB/s** |
+| RPS | 21,989 | 20,550 |
+| Avg Latency | 4.59ms | 9.90ms |
+| Max Latency | 41.64ms | 65.83ms |
+| Throughput | 71.88MB/s | 67.42MB/s |
 
 ## Key Findings
 
-✅ **High Throughput**: Sustained 20K+ requests per second  
-✅ **Low Latency**: Sub-10ms average response time under load  
-✅ **Stability**: Consistent performance during extended tests  
-✅ **Scalability**: Maintains performance with increased concurrency  
+- High Throughput: Sustained 20K+ requests per second
+- Low Latency: Sub-10ms average response time under load
+- Stability: Consistent performance during extended tests
+- Scalability: Maintains performance with increased concurrency
 
 ## Production Readiness
 
-RustyGW demonstrates production-grade performance characteristics:
+RustyGW demonstrates production-grade performance:
 
-- **Handles 20K+ concurrent requests per second**
-- **Maintains sub-millisecond latency under normal load**
-- **Scales efficiently with increased connection count**
-- **Stable performance during sustained load tests**
+- Handles 20K+ concurrent requests per second
+- Maintains sub-millisecond latency under normal load
+- Scales efficiently with increased connection count
+- Stable performance during sustained load tests
 
 ## Test Reproduction
 
@@ -69,12 +73,16 @@ To reproduce these tests:
 
 1. Deploy RustyGW on your target server
 2. Install wrk: `sudo apt install wrk` or compile from source
-3. Run moderate test: `wrk -t4 -c100 -d30s http://localhost:8094/metrics`
-4. Run extreme test: `wrk -t8 -c200 -d60s http://localhost:8094/metrics`
+3. Run moderate test:
+   `wrk -t4 -c100 -d30s http://localhost:8094/metrics`
+4. Run extreme test:
+   `wrk -t8 -c200 -d60s http://localhost:8094/metrics`
 
 ## Hardware Specifications
 
-Tests performed on standard cloud server configuration. Actual performance may vary based on:
+Tests performed on standard cloud server configuration.
+Actual performance may vary based on:
+
 - CPU cores and frequency
 - Available RAM
 - Network bandwidth

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # RustyGW
 
-A high-performance internal API Gateway for microservices. Designed for backend-to-frontend (BTF) and backend-to-backend (BTB) communication within a service stack.
+A high-performance internal API Gateway for microservices.
+Designed for BTF and BTB communication within a service stack.
 
-> Built upon [Rust-API-Gateway](https://github.com/Ketankhunti/Rust-API-Gateway) by [@Ketankhunti](https://github.com/Ketankhunti), extended with load balancing, WebSocket/gRPC proxy, API composition, health checks, distributed tracing, and production-grade resilience.
+> Built upon [Rust-API-Gateway](https://github.com/Ketankhunti/Rust-API-Gateway)
+> by [@Ketankhunti](https://github.com/Ketankhunti),
+> extended with load balancing, WebSocket/gRPC proxy,
+> API composition, health checks, distributed tracing,
+> and production-grade resilience.
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.92+-orange.svg)](https://www.rust-lang.org)
@@ -13,29 +18,34 @@ A high-performance internal API Gateway for microservices. Designed for backend-
 ## Features
 
 ### Proxy
+
 - **HTTP Proxy** with path-based routing
 - **WebSocket Proxy** (`/ws/`) for real-time BTF communication
 - **gRPC Proxy** (`/grpc/`) with HTTP/2 transparent forwarding
 - **API Composition** (`/agg/`) — fan-out 1 request to N backends, merge responses
 
 ### Resilience
+
 - **Load Balancing** — round-robin, random across multiple destinations
 - **Active Health Checks** — periodic probes, auto-remove/recover backends
 - **Retry + Timeout** — per-route retry count, backoff, status codes, timeout
 - **Circuit Breaker** — fault tolerance with configurable thresholds
 
 ### Transformation
+
 - **Path Rewriting** — rewrite request paths with `{path}` placeholder
 - **Header Injection/Removal** — add or remove request and response headers
 - **Response Compression** — automatic gzip
 
 ### Observability
+
 - **Prometheus Metrics** — request count, latency histograms, error rates
 - **W3C Distributed Tracing** — auto-generate and propagate `traceparent`
 - **Structured Access Logs** — method, path, status, duration_ms per request
 - **Health Endpoint** — `GET /health` returns `OK`
 
 ### Security
+
 - **JWT + API Key Authentication** with RBAC
 - **Rate Limiting** — per-IP (BTF) or per-service via `x-service-name` header (BTB)
 - **CORS** — configurable origins, methods, headers
@@ -43,6 +53,7 @@ A high-performance internal API Gateway for microservices. Designed for backend-
 - **Body Size Limits** — configurable max request body
 
 ### Operations
+
 - **Service Abstraction** — define services once, reference in routes
 - **Global Defaults** — timeout, retry, load_balance applied to all routes
 - **Environment Variables** — `${VAR}` interpolation in YAML config
@@ -191,7 +202,7 @@ routes:
 
 Frontend calls RustyGW as its single entry point:
 
-```
+```text
 Browser → RustyGW:8094 → Backend services
 ```
 
@@ -201,7 +212,7 @@ Key features: API composition, CORS, WebSocket proxy, gzip compression, rate lim
 # 1 call = data from 3 services
 curl http://gateway:8094/agg/api/dashboard
 # → {"user": {...}, "orders": [...], "notifications": [...]}
-
+```bash
 # WebSocket through gateway
 wscat -c ws://gateway:8094/ws/api/live
 ```
@@ -210,7 +221,7 @@ wscat -c ws://gateway:8094/ws/api/live
 
 Services call RustyGW instead of calling each other directly:
 
-```
+```text
 Service A → RustyGW:8094 → Service B (with LB, retry, health checks)
 ```
 
@@ -226,7 +237,7 @@ curl -H "x-service-name: order-service" http://gateway:8094/api/payments
 ## Endpoints
 
 | Path | Protocol | Description |
-|------|----------|-------------|
+| ------ | ---------- | ------------- |
 | `/{path}` | HTTP | Standard proxy with auth/rate-limit middleware |
 | `/ws/{path}` | WebSocket | Bidirectional WebSocket proxy |
 | `/agg/{path}` | HTTP | API composition (fan-out + merge) |
@@ -239,7 +250,7 @@ curl -H "x-service-name: order-service" http://gateway:8094/api/payments
 ## Performance
 
 | Metric | Value |
-|--------|-------|
+| -------- | ------- |
 | Throughput | 20,000+ req/sec |
 | Avg Latency | 4.59ms (100 connections) |
 | Max Latency | 41.64ms under load |
@@ -262,14 +273,16 @@ docker service scale rustygw_gateway=3
 
 ### Architecture with Traefik
 
-```
+```text
 Internet → Traefik (TLS/edge) → Services
                                     ↓
                           Service A → RustyGW → Service B (BTB)
                           Frontend  → RustyGW → Backends  (BTF)
 ```
 
-RustyGW sits behind Traefik inside the Swarm overlay network. Traefik handles external TLS, RustyGW handles internal routing, load balancing, and resilience.
+RustyGW sits behind Traefik inside the Swarm overlay network.
+Traefik handles external TLS, RustyGW handles internal routing,
+load balancing, and resilience.
 
 ---
 
@@ -287,7 +300,11 @@ cargo watch -x run   # Hot reload dev
 
 ## Acknowledgments
 
-Built upon [Rust-API-Gateway](https://github.com/Ketankhunti/Rust-API-Gateway) by [@Ketankhunti](https://github.com/Ketankhunti). Extended with load balancing, WebSocket/gRPC proxy, API composition, health checks, distributed tracing, CORS, compression, and production-grade resilience patterns.
+Built upon [Rust-API-Gateway](https://github.com/Ketankhunti/Rust-API-Gateway)
+by [@Ketankhunti](https://github.com/Ketankhunti).
+Extended with load balancing, WebSocket/gRPC proxy, API composition,
+health checks, distributed tracing, CORS, compression,
+and production-grade resilience patterns.
 
 ## License
 

--- a/benches/gateway_bench.rs
+++ b/benches/gateway_bench.rs
@@ -17,9 +17,7 @@ fn bench_hashmap_lookup(c: &mut Criterion) {
         b.iter(|| black_box(map.get("/api/v1/route500")))
     });
 
-    group.bench_function("hashmap_miss", |b| {
-        b.iter(|| black_box(map.get("/api/v1/nonexistent")))
-    });
+    group.bench_function("hashmap_miss", |b| b.iter(|| black_box(map.get("/api/v1/nonexistent"))));
 
     group.finish();
 }
@@ -83,9 +81,7 @@ fn bench_token_bucket(c: &mut Criterion) {
     let mut group = c.benchmark_group("rate_limiting");
     group.throughput(Throughput::Elements(1));
 
-    group.bench_function("token_acquire", |b| {
-        b.iter(|| black_box(bucket.try_acquire()))
-    });
+    group.bench_function("token_acquire", |b| b.iter(|| black_box(bucket.try_acquire())));
 
     group.finish();
 }

--- a/docs/STANDARDS.md
+++ b/docs/STANDARDS.md
@@ -21,14 +21,14 @@
     +-- main.rs           Entry point
     +-- lib.rs             App builder and HTTP client setup
     +-- app.rs             Axum router and middleware stack
-    +-- config.rs          YAML config loading, validation, route tree
-    +-- errors.rs          AppError enum and IntoResponse impl
+    +-- config.rs          Config loading, validation, route tree
+    +-- errors.rs          AppError enum and IntoResponse
     +-- proxy.rs           HTTP reverse proxy handler
     +-- ws_proxy.rs        WebSocket proxy handler
     +-- grpc_proxy.rs      gRPC transparent proxy (HTTP/2)
     +-- aggregate.rs       Multi-service response aggregation
     +-- state.rs           Shared application state
-    +-- features/          Core features (auth, circuit breaker, health, LB, rate limit)
+    +-- features/          Core features (auth, CB, health, LB)
     +-- middleware/         Axum middleware layers
     +-- utils/             Hot reload, metrics, config path helpers
     +-- plugins/           Plugin system (experimental)

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+edition = "2024"
+max_width = 120
+use_field_init_shorthand = true

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -18,10 +18,7 @@ fn json_response(status: StatusCode, body: impl Into<Body>) -> Response {
         .unwrap_or_else(|_| Response::new(Body::empty()))
 }
 
-pub async fn aggregate_handler(
-    State(state): State<Arc<AppState>>,
-    Path(path): Path<String>,
-) -> Response {
+pub async fn aggregate_handler(State(state): State<Arc<AppState>>, Path(path): Path<String>) -> Response {
     let request_path = format!("/{}", path);
 
     let (sources, route_name) = {

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,17 +13,15 @@ use tower_http::{compression::CompressionLayer, cors::CorsLayer, trace::TraceLay
 use uuid::Uuid;
 
 use crate::{
-    middleware::{
-        auth::auth::layer as auth_layer, cache::cache::layer as cache_layer,
-        circuit_breaker::circuit_breaker::layer as circuit_breaker_layer,
-        rate_limiter::rate_limit::layer as ratelimiter_layer,
-        request_id::request_id::layer as request_id_layer,
-        tracing_ctx::layer as tracing_ctx_layer,
-        access_log::layer as access_log_layer,
-    },
-    proxy::proxy_handler,
     aggregate::aggregate_handler,
     grpc_proxy::grpc_proxy_handler,
+    middleware::{
+        access_log::layer as access_log_layer, auth::auth::layer as auth_layer, cache::cache::layer as cache_layer,
+        circuit_breaker::circuit_breaker::layer as circuit_breaker_layer,
+        rate_limiter::rate_limit::layer as ratelimiter_layer, request_id::request_id::layer as request_id_layer,
+        tracing_ctx::layer as tracing_ctx_layer,
+    },
+    proxy::proxy_handler,
     state::AppState,
     utils::metric_handler::metrics_handler,
     ws_proxy::ws_proxy_handler,
@@ -46,19 +44,11 @@ pub fn create_app(state: Arc<AppState>, cors: &crate::config::CorsConfig, body_l
 
     // Build CORS layer
     let cors_layer = if cors.enabled {
-        let origins: Vec<_> = cors.origins.iter()
-            .filter_map(|o| o.parse().ok())
-            .collect();
-        let methods: Vec<HttpMethod> = cors.methods.iter()
-            .filter_map(|m| m.parse().ok())
-            .collect();
-        let mut layer = CorsLayer::new()
-            .allow_methods(methods)
-            .allow_origin(origins);
+        let origins: Vec<_> = cors.origins.iter().filter_map(|o| o.parse().ok()).collect();
+        let methods: Vec<HttpMethod> = cors.methods.iter().filter_map(|m| m.parse().ok()).collect();
+        let mut layer = CorsLayer::new().allow_methods(methods).allow_origin(origins);
         if !cors.allow_headers.is_empty() {
-            let headers: Vec<HeaderName> = cors.allow_headers.iter()
-                .filter_map(|h| h.parse().ok())
-                .collect();
+            let headers: Vec<HeaderName> = cors.allow_headers.iter().filter_map(|h| h.parse().ok()).collect();
             layer = layer.allow_headers(headers);
         } else {
             layer = layer.allow_headers(tower_http::cors::Any);
@@ -91,22 +81,20 @@ pub fn create_app(state: Arc<AppState>, cors: &crate::config::CorsConfig, body_l
         .layer(axum::extract::DefaultBodyLimit::max(body_limit));
 
     Ok(router
-        .layer(
-            TraceLayer::new_for_http().make_span_with(|request: &Request<_>| {
-                let uuid = Uuid::new_v4().to_string();
-                let request_id = request
-                    .headers()
-                    .get(REQUEST_ID_HEADER)
-                    .and_then(|value| value.to_str().ok())
-                    .unwrap_or(uuid.as_str());
+        .layer(TraceLayer::new_for_http().make_span_with(|request: &Request<_>| {
+            let uuid = Uuid::new_v4().to_string();
+            let request_id = request
+                .headers()
+                .get(REQUEST_ID_HEADER)
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or(uuid.as_str());
 
-                tracing::error_span!(
-                        "request",
-                        id = %request_id,
-                        method = %request.method(),
-                        uri = %request.uri(),
-                )
-            }),
-        )
+            tracing::error_span!(
+                    "request",
+                    id = %request_id,
+                    method = %request.method(),
+                    uri = %request.uri(),
+            )
+        }))
         .layer(from_fn(request_id_layer)))
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,11 +78,21 @@ pub struct PoolConfig {
     pub body_limit: String,
 }
 
-fn default_pool_idle_timeout() -> String { "90s".to_string() }
-fn default_pool_max_idle() -> usize { 32 }
-fn default_connect_timeout() -> String { "5s".to_string() }
-fn default_request_timeout() -> String { "30s".to_string() }
-fn default_body_limit() -> String { "10mb".to_string() }
+fn default_pool_idle_timeout() -> String {
+    "90s".to_string()
+}
+fn default_pool_max_idle() -> usize {
+    32
+}
+fn default_connect_timeout() -> String {
+    "5s".to_string()
+}
+fn default_request_timeout() -> String {
+    "30s".to_string()
+}
+fn default_body_limit() -> String {
+    "10mb".to_string()
+}
 
 impl Default for PoolConfig {
     fn default() -> Self {
@@ -110,8 +120,19 @@ pub struct CorsConfig {
     pub enabled: bool,
 }
 
-fn default_cors_origins() -> Vec<String> { vec!["*".to_string()] }
-fn default_cors_methods() -> Vec<String> { vec!["GET".into(), "POST".into(), "PUT".into(), "DELETE".into(), "PATCH".into(), "OPTIONS".into()] }
+fn default_cors_origins() -> Vec<String> {
+    vec!["*".to_string()]
+}
+fn default_cors_methods() -> Vec<String> {
+    vec![
+        "GET".into(),
+        "POST".into(),
+        "PUT".into(),
+        "DELETE".into(),
+        "PATCH".into(),
+        "OPTIONS".into(),
+    ]
+}
 
 // ==================== Identity ====================
 
@@ -175,8 +196,12 @@ pub struct RetryConfig {
     pub backoff: String,
 }
 
-fn default_retries() -> u32 { 2 }
-fn default_backoff() -> String { "100ms".to_string() }
+fn default_retries() -> u32 {
+    2
+}
+fn default_backoff() -> String {
+    "100ms".to_string()
+}
 
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct TransformConfig {
@@ -296,34 +321,34 @@ impl GatewayConfig {
             if let Some(svc_name) = &route.service
                 && let Some(svc) = services.get(svc_name)
             {
-                    let route_mut = Arc::make_mut(route);
-                    // Set destinations from service
-                    if route_mut.destinations.is_empty() && route_mut.destination.is_empty() {
-                        if !svc.urls.is_empty() {
-                            route_mut.destinations = svc.urls.clone();
-                        } else if let Some(url) = &svc.url {
-                            route_mut.destination = url.clone();
-                        }
+                let route_mut = Arc::make_mut(route);
+                // Set destinations from service
+                if route_mut.destinations.is_empty() && route_mut.destination.is_empty() {
+                    if !svc.urls.is_empty() {
+                        route_mut.destinations = svc.urls.clone();
+                    } else if let Some(url) = &svc.url {
+                        route_mut.destination = url.clone();
                     }
-                    // Inherit service config if not set on route
-                    if route_mut.health_check.is_none() {
-                        route_mut.health_check = svc.health_check.clone();
-                    }
-                    if route_mut.retry.is_none() {
-                        route_mut.retry = svc.retry.clone();
-                    }
-                    if route_mut.timeout.is_none() {
-                        route_mut.timeout = svc.timeout.clone();
-                    }
-                    if !route_mut.tls_skip_verify {
-                        route_mut.tls_skip_verify = svc.tls_skip_verify;
-                    }
-                    if matches!(route_mut.load_balance, LoadBalanceStrategy::RoundRobin) {
-                        route_mut.load_balance = svc.load_balance.clone();
-                    }
+                }
+                // Inherit service config if not set on route
+                if route_mut.health_check.is_none() {
+                    route_mut.health_check = svc.health_check.clone();
+                }
+                if route_mut.retry.is_none() {
+                    route_mut.retry = svc.retry.clone();
+                }
+                if route_mut.timeout.is_none() {
+                    route_mut.timeout = svc.timeout.clone();
+                }
+                if !route_mut.tls_skip_verify {
+                    route_mut.tls_skip_verify = svc.tls_skip_verify;
+                }
+                if matches!(route_mut.load_balance, LoadBalanceStrategy::RoundRobin) {
+                    route_mut.load_balance = svc.load_balance.clone();
                 }
             }
         }
+    }
 
     /// #62: Apply global defaults to routes missing config
     fn apply_defaults(&mut self) {
@@ -388,15 +413,18 @@ impl GatewayConfig {
         if errors.is_empty() {
             Ok(())
         } else {
-            Err(anyhow::anyhow!("Config validation errors:\n  - {}", errors.join("\n  - ")))
+            Err(anyhow::anyhow!(
+                "Config validation errors:\n  - {}",
+                errors.join("\n  - ")
+            ))
         }
     }
 
     pub fn find_route_for_path(&self, request_path: &str) -> Option<Arc<RouteConfig>> {
-        if let Some(ref tree) = self.route_tree {
-            if let std::result::Result::Ok(matched) = tree.at(request_path) {
-                return Some(self.routes[*matched.value].clone());
-            }
+        if let Some(ref tree) = self.route_tree
+            && let std::result::Result::Ok(matched) = tree.at(request_path)
+        {
+            return Some(self.routes[*matched.value].clone());
         }
         // Fallback to prefix matching for catch-all routes like "/"
         self.routes
@@ -407,14 +435,17 @@ impl GatewayConfig {
     }
 
     /// Match a path and return captured parameters for proxy substitution
+    #[allow(clippy::type_complexity)]
     pub fn match_route_with_params(&self, request_path: &str) -> Option<(Arc<RouteConfig>, Vec<(String, String)>)> {
-        if let Some(ref tree) = self.route_tree {
-            if let std::result::Result::Ok(matched) = tree.at(request_path) {
-                let params: Vec<(String, String)> = matched.params.iter()
-                    .map(|(_k, _v)| (_k.to_string(), _v.to_string()))
-                    .collect();
-                return Some((self.routes[*matched.value].clone(), params));
-            }
+        if let Some(ref tree) = self.route_tree
+            && let std::result::Result::Ok(matched) = tree.at(request_path)
+        {
+            let params: Vec<(String, String)> = matched
+                .params
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect();
+            return Some((self.routes[*matched.value].clone(), params));
         }
         // Fallback: no params
         self.find_route_for_path(request_path).map(|r| (r, vec![]))
@@ -432,10 +463,18 @@ impl GatewayConfig {
     }
 
     /// Public wrappers for testing
-    pub fn resolve_services_pub(&mut self) { self.resolve_services(); }
-    pub fn apply_defaults_pub(&mut self) { self.apply_defaults(); }
-    pub fn validate_pub(&self) -> Result<(), anyhow::Error> { self.validate() }
-    pub fn build_route_tree_pub(&mut self) { self.build_route_tree(); }
+    pub fn resolve_services_pub(&mut self) {
+        self.resolve_services();
+    }
+    pub fn apply_defaults_pub(&mut self) {
+        self.apply_defaults();
+    }
+    pub fn validate_pub(&self) -> Result<(), anyhow::Error> {
+        self.validate()
+    }
+    pub fn build_route_tree_pub(&mut self) {
+        self.build_route_tree();
+    }
 }
 
 /// Public wrapper for env var interpolation (for testing)
@@ -447,13 +486,14 @@ pub fn interpolate_env_vars_pub(content: &str) -> String {
 
 fn interpolate_env_vars(content: &str) -> String {
     use std::sync::LazyLock;
-    static ENV_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"\$\{([^}]+)\}").expect("Invalid env var regex — this is a compile-time bug")
-    });
-    ENV_RE.replace_all(content, |caps: &regex::Captures| {
-        let var_name = &caps[1];
-        std::env::var(var_name).unwrap_or_else(|_| format!("${{{}}}", var_name))
-    }).to_string()
+    static ENV_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\$\{([^}]+)\}").expect("Invalid env var regex — this is a compile-time bug"));
+    ENV_RE
+        .replace_all(content, |caps: &regex::Captures| {
+            let var_name = &caps[1];
+            std::env::var(var_name).unwrap_or_else(|_| format!("${{{}}}", var_name))
+        })
+        .to_string()
 }
 
 // ==================== Include Merging (#65) ====================
@@ -487,7 +527,9 @@ pub struct ApiKeyDetails {
     pub status: String,
 }
 
-fn default_status() -> String { "active".to_string() }
+fn default_status() -> String {
+    "active".to_string()
+}
 
 impl ApiKeyStore {
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, anyhow::Error> {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -26,18 +26,9 @@ pub enum AppError {
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         let (status, error_message) = match self {
-            AppError::RateLimited => (
-                StatusCode::TOO_MANY_REQUESTS,
-                "Too many requests".to_string(),
-            ),
-            AppError::AuthFailed(reason) => (
-                StatusCode::UNAUTHORIZED,
-                format!("Authentication failed: {}", reason),
-            ),
-            AppError::MissingAuthToken => (
-                StatusCode::UNAUTHORIZED,
-                "Missing 'Authorization' header".to_string(),
-            ),
+            AppError::RateLimited => (StatusCode::TOO_MANY_REQUESTS, "Too many requests".to_string()),
+            AppError::AuthFailed(reason) => (StatusCode::UNAUTHORIZED, format!("Authentication failed: {}", reason)),
+            AppError::MissingAuthToken => (StatusCode::UNAUTHORIZED, "Missing 'Authorization' header".to_string()),
             AppError::InvalidAuthHeader => (
                 StatusCode::UNAUTHORIZED,
                 "Invalid 'Authorization' header format. Expected 'Bearer <token>'.".to_string(),
@@ -50,10 +41,7 @@ impl IntoResponse for AppError {
             AppError::RouteNotFound => (StatusCode::NOT_FOUND, "Route not found".to_string()),
             AppError::ProxyError(e) => {
                 tracing::error!("Proxy error: {}", e);
-                (
-                    StatusCode::BAD_GATEWAY,
-                    "Error proxying request".to_string(),
-                )
+                (StatusCode::BAD_GATEWAY, "Error proxying request".to_string())
             }
             AppError::InvalidDestination(url) => {
                 tracing::error!("Invalid destination URL configured: {}", url);
@@ -66,10 +54,7 @@ impl IntoResponse for AppError {
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "An internal server error occurred".to_string(),
             ),
-            AppError::ServiceUnavailable => (
-                StatusCode::SERVICE_UNAVAILABLE,
-                "Service Unavailable".to_string(),
-            ),
+            AppError::ServiceUnavailable => (StatusCode::SERVICE_UNAVAILABLE, "Service Unavailable".to_string()),
         };
 
         (status, error_message).into_response()

--- a/src/features/auth/auth.rs
+++ b/src/features/auth/auth.rs
@@ -37,9 +37,7 @@ fn extract_bearer_token(headers: &HeaderMap) -> Result<&str, AppError> {
         .and_then(|value| value.to_str().ok())
         .ok_or(AppError::MissingAuthToken)?;
 
-    auth_header
-        .strip_prefix("Bearer ")
-        .ok_or(AppError::InvalidAuthHeader)
+    auth_header.strip_prefix("Bearer ").ok_or(AppError::InvalidAuthHeader)
 }
 
 pub fn check_roles(user_roles: &[String], required_roles: &[String]) -> Result<(), AppError> {

--- a/src/features/health_check.rs
+++ b/src/features/health_check.rs
@@ -39,10 +39,7 @@ impl HealthChecker {
     }
 
     pub fn is_healthy(&self, url: &str) -> bool {
-        self.status
-            .get(url)
-            .map(|h| h.healthy)
-            .unwrap_or(true) // assume healthy if not checked yet
+        self.status.get(url).map(|h| h.healthy).unwrap_or(true) // assume healthy if not checked yet
     }
 
     pub fn filter_healthy<'a>(&self, destinations: &[&'a str]) -> Vec<&'a str> {

--- a/src/features/load_balancer.rs
+++ b/src/features/load_balancer.rs
@@ -26,9 +26,7 @@ impl LoadBalancer {
             return None;
         }
         Some(match strategy {
-            LoadBalanceStrategy::RoundRobin => {
-                self.counter.fetch_add(1, Ordering::Relaxed) % count
-            }
+            LoadBalanceStrategy::RoundRobin => self.counter.fetch_add(1, Ordering::Relaxed) % count,
             LoadBalanceStrategy::Random => {
                 use std::collections::hash_map::RandomState;
                 use std::hash::{BuildHasher, Hasher};

--- a/src/grpc_proxy.rs
+++ b/src/grpc_proxy.rs
@@ -69,9 +69,7 @@ pub async fn grpc_proxy_handler(
         }
     };
 
-    let client = Client::builder(TokioExecutor::new())
-        .http2_only(true)
-        .build_http();
+    let client = Client::builder(TokioExecutor::new()).http2_only(true).build_http();
 
     match client.request(request).await {
         Ok(resp) => {
@@ -87,7 +85,9 @@ pub async fn grpc_proxy_handler(
             for (key, value) in parts.headers.iter() {
                 response = response.header(key, value);
             }
-            response.body(Body::from(bytes)).unwrap_or_else(|_| Response::new(Body::empty()))
+            response
+                .body(Body::from(bytes))
+                .unwrap_or_else(|_| Response::new(Body::empty()))
         }
         Err(e) => {
             error!(destination = %dest_url, "gRPC proxy error: {}", e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,11 +148,7 @@ pub async fn run(config_path: PathBuf) -> Result<()> {
 
     let listener = TcpListener::bind(&addr).await?;
     info!("Gateway listening on {}", &addr);
-    axum::serve(
-        listener,
-        app.into_make_service_with_connect_info::<SocketAddr>(),
-    )
-    .await?;
+    axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await?;
 
     Ok(())
 }

--- a/src/middleware/auth/auth.rs
+++ b/src/middleware/auth/auth.rs
@@ -16,11 +16,7 @@ use crate::{
 };
 
 // axum middleware layer for authentication
-pub async fn layer(
-    State(state): State<Arc<AppState>>,
-    mut req: Request,
-    next: Next,
-) -> Result<Response, AppError> {
+pub async fn layer(State(state): State<Arc<AppState>>, mut req: Request, next: Next) -> Result<Response, AppError> {
     let route = find_route_for_uri(req.uri(), state.clone()).await?;
 
     if let Some(auth_config) = &route.auth {

--- a/src/middleware/cache/cache.rs
+++ b/src/middleware/cache/cache.rs
@@ -14,11 +14,7 @@ use crate::{
     state::{AppState, CachedResponse},
 };
 
-pub async fn layer(
-    State(state): State<Arc<AppState>>,
-    req: Request<Body>,
-    next: Next,
-) -> Result<Response, AppError> {
+pub async fn layer(State(state): State<Arc<AppState>>, req: Request<Body>, next: Next) -> Result<Response, AppError> {
     let config_guard = state.config.read().await;
 
     let route = config_guard.find_route_for_path(req.uri().path());

--- a/src/middleware/circuit_breaker/circuit_breaker.rs
+++ b/src/middleware/circuit_breaker/circuit_breaker.rs
@@ -12,11 +12,7 @@ use crate::{
     middleware::rate_limiter::rate_limit::parse_duration, state::AppState,
 };
 
-pub async fn layer(
-    State(state): State<Arc<AppState>>,
-    req: Request,
-    next: Next,
-) -> Result<Response, AppError> {
+pub async fn layer(State(state): State<Arc<AppState>>, req: Request, next: Next) -> Result<Response, AppError> {
     let config_guard = state.config.read().await;
     let route = match config_guard.find_route_for_path(req.uri().path()) {
         Some(r) => r,
@@ -67,9 +63,7 @@ pub async fn layer(
             CircuitStateEnum::HalfOpen { .. } | CircuitStateEnum::Closed { .. } => {
                 // If a trial fails OR a normal request fails, we check the failure threshold.
                 let failures = match *final_state {
-                    CircuitStateEnum::Closed {
-                        consecutive_failures,
-                    } => consecutive_failures + 1,
+                    CircuitStateEnum::Closed { consecutive_failures } => consecutive_failures + 1,
                     _ => 1, // First failure in HalfOpen state
                 };
 
@@ -89,9 +83,7 @@ pub async fn layer(
     } else {
         // Request Succeded
         match *final_state {
-            CircuitStateEnum::HalfOpen {
-                consecutive_successes,
-            } => {
+            CircuitStateEnum::HalfOpen { consecutive_successes } => {
                 let new_successes = consecutive_successes + 1;
                 if new_successes >= cb_config.success_threshold {
                     // Success threshold reached, close the circuit.
@@ -107,9 +99,7 @@ pub async fn layer(
                     info!(route = %route.name, successes = new_successes, "Trial request succeeded, remaining HALF-OPEN");
                 }
             }
-            CircuitStateEnum::Closed {
-                consecutive_failures,
-            } => {
+            CircuitStateEnum::Closed { consecutive_failures } => {
                 if consecutive_failures > 0 {
                     // Reset failure count on success.
                     *final_state = CircuitStateEnum::Closed {

--- a/src/middleware/rate_limiter/rate_limit.rs
+++ b/src/middleware/rate_limiter/rate_limit.rs
@@ -23,13 +23,13 @@ pub async fn layer(
     if let Some(route_config) = route
         && let Some(rate_limit_config) = route_config.rate_limit.as_ref()
     {
-        let period =
-            parse_duration(&rate_limit_config.period).unwrap_or_else(|_| Duration::from_secs(60));
+        let period = parse_duration(&rate_limit_config.period).unwrap_or_else(|_| Duration::from_secs(60));
         let capacity = rate_limit_config.requests;
         let refill_rate = rate_limit_config.requests as f64 / period.as_secs_f64();
 
         // Use x-service-name header if present (BTB), otherwise client IP (BTF)
-        let key = req.headers()
+        let key = req
+            .headers()
             .get("x-service-name")
             .and_then(|v| v.to_str().ok())
             .map(|s| format!("svc:{}", s))
@@ -50,9 +50,7 @@ pub async fn layer(
 pub fn parse_duration(s: &str) -> Result<Duration, &'static str> {
     let s = s.trim();
     let unit = s.chars().last().ok_or("Empty durtion")?;
-    let value: u64 = s[..s.len() - 1]
-        .parse()
-        .map_err(|_| "Invalid number in duration")?;
+    let value: u64 = s[..s.len() - 1].parse().map_err(|_| "Invalid number in duration")?;
 
     match unit {
         's' => Ok(Duration::from_secs(value)),

--- a/src/middleware/request_id/request_id.rs
+++ b/src/middleware/request_id/request_id.rs
@@ -20,9 +20,10 @@ pub async fn layer(mut req: Request<Body>, next: Next) -> Response {
         Some(id) => id,
         None => {
             let new_id = Uuid::new_v4().to_string();
-            req.headers_mut()
-                .insert(REQUEST_ID_HEADER, HeaderValue::from_str(&new_id)
-                    .unwrap_or_else(|_| HeaderValue::from_static("unknown")));
+            req.headers_mut().insert(
+                REQUEST_ID_HEADER,
+                HeaderValue::from_str(&new_id).unwrap_or_else(|_| HeaderValue::from_static("unknown")),
+            );
             new_id
         }
     };

--- a/src/plugins/examples.rs
+++ b/src/plugins/examples.rs
@@ -25,11 +25,7 @@ impl Plugin for HeaderInjectorPlugin {
         PluginPhase::PostProxy
     }
 
-    async fn on_response(
-        &self,
-        mut response: Response<Body>,
-        _ctx: &PluginContext,
-    ) -> PluginResult<Response<Body>> {
+    async fn on_response(&self, mut response: Response<Body>, _ctx: &PluginContext) -> PluginResult<Response<Body>> {
         for (key, value) in &self.headers {
             if let Ok(hv) = HeaderValue::from_str(value)
                 && let Ok(hn) = http::header::HeaderName::try_from(key.as_str())

--- a/src/plugins/plugin.rs
+++ b/src/plugins/plugin.rs
@@ -62,11 +62,7 @@ pub trait Plugin: Send + Sync {
         Ok((request, None))
     }
 
-    async fn on_response(
-        &self,
-        response: Response<Body>,
-        _ctx: &PluginContext,
-    ) -> PluginResult<Response<Body>> {
+    async fn on_response(&self, response: Response<Body>, _ctx: &PluginContext) -> PluginResult<Response<Body>> {
         Ok(response)
     }
 

--- a/src/plugins/registry.rs
+++ b/src/plugins/registry.rs
@@ -38,11 +38,7 @@ impl PluginRegistry {
             .collect()
     }
 
-    pub async fn get_plugins_for_route(
-        &self,
-        route_path: &str,
-        phase: PluginPhase,
-    ) -> Vec<BoxedPlugin> {
+    pub async fn get_plugins_for_route(&self, route_path: &str, phase: PluginPhase) -> Vec<BoxedPlugin> {
         self.plugins
             .read()
             .await

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -48,7 +48,9 @@ pub async fn proxy_handler(
     };
 
     // Apply path rewrite if configured
-    let final_path = route.transform.as_ref()
+    let final_path = route
+        .transform
+        .as_ref()
         .and_then(|t| t.rewrite_path.as_ref())
         .map(|rewrite| rewrite.replace("{path}", destination_path))
         .unwrap_or_else(|| destination_path.to_string());
@@ -61,7 +63,9 @@ pub async fn proxy_handler(
         url
     };
 
-    let route_timeout = route.timeout.as_ref()
+    let route_timeout = route
+        .timeout
+        .as_ref()
         .map(|t| crate::features::health_check::parse_duration(t));
 
     info!(destination = %destination_url, strategy = ?route.load_balance, "Forwarding request to backend");
@@ -73,15 +77,18 @@ pub async fn proxy_handler(
         }
         for (key, value) in &transform.request_headers {
             if let Ok(v) = HeaderValue::from_str(value) {
-                headers.insert(http::header::HeaderName::from_bytes(key.as_bytes()).unwrap_or(http::header::HeaderName::from_static("x-invalid")), v);
+                headers.insert(
+                    http::header::HeaderName::from_bytes(key.as_bytes())
+                        .unwrap_or(http::header::HeaderName::from_static("x-invalid")),
+                    v,
+                );
             }
         }
     }
 
     headers.insert(
         REQUEST_ID_HEADER,
-        HeaderValue::from_str(&request_id)
-            .unwrap_or_else(|_| HeaderValue::from_static("unknown")),
+        HeaderValue::from_str(&request_id).unwrap_or_else(|_| HeaderValue::from_static("unknown")),
     );
 
     let body_bytes: Bytes = body
@@ -94,10 +101,20 @@ pub async fn proxy_handler(
         .to_bytes();
 
     let max_attempts = route.retry.as_ref().map(|r| r.count + 1).unwrap_or(1);
-    let retry_on: Vec<u16> = route.retry.as_ref()
-        .map(|r| if r.retry_on.is_empty() { vec![502, 503, 504] } else { r.retry_on.clone() })
+    let retry_on: Vec<u16> = route
+        .retry
+        .as_ref()
+        .map(|r| {
+            if r.retry_on.is_empty() {
+                vec![502, 503, 504]
+            } else {
+                r.retry_on.clone()
+            }
+        })
         .unwrap_or_default();
-    let backoff = route.retry.as_ref()
+    let backoff = route
+        .retry
+        .as_ref()
         .map(|r| crate::features::health_check::parse_duration(&r.backoff))
         .unwrap_or(std::time::Duration::from_millis(100));
 
@@ -139,12 +156,10 @@ pub async fn proxy_handler(
                 for (name, value) in resp_headers.iter() {
                     response_builder = response_builder.header(name, value);
                 }
-                let mut response = response_builder.body(body)
-                    .map_err(|_| AppError::InternalServerError)?;
+                let mut response = response_builder.body(body).map_err(|_| AppError::InternalServerError)?;
                 response.headers_mut().insert(
                     REQUEST_ID_HEADER,
-                    HeaderValue::from_str(&request_id)
-                        .unwrap_or_else(|_| HeaderValue::from_static("unknown")),
+                    HeaderValue::from_str(&request_id).unwrap_or_else(|_| HeaderValue::from_static("unknown")),
                 );
                 // Apply response header transformations
                 if let Some(transform) = &route.transform {
@@ -152,7 +167,10 @@ pub async fn proxy_handler(
                         response.headers_mut().remove(key.as_str());
                     }
                     for (key, value) in &transform.response_headers {
-                        if let (Ok(k), Ok(v)) = (http::header::HeaderName::from_bytes(key.as_bytes()), HeaderValue::from_str(value)) {
+                        if let (Ok(k), Ok(v)) = (
+                            http::header::HeaderName::from_bytes(key.as_bytes()),
+                            HeaderValue::from_str(value),
+                        ) {
                             response.headers_mut().insert(k, v);
                         }
                     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -8,10 +8,8 @@ use std::{sync::Arc, time::Instant};
 use crate::{
     config::{ApiKeyStore, GatewayConfig, SecretsConfig},
     features::{
-        circuit_breaker::circuit_breaker::CircuitBreakerStore,
-        health_check::HealthChecker,
-        load_balancer::LoadBalancer,
-        rate_limiter::state::RateLimitState,
+        circuit_breaker::circuit_breaker::CircuitBreakerStore, health_check::HealthChecker,
+        load_balancer::LoadBalancer, rate_limiter::state::RateLimitState,
     },
     plugins::PluginRegistry,
 };

--- a/src/utils/config_path.rs
+++ b/src/utils/config_path.rs
@@ -4,11 +4,6 @@ use std::path::PathBuf;
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 pub struct Cli {
-    #[arg(
-        short,
-        long,
-        value_name = "FILE",
-        default_value = "gateway_config.yaml"
-    )]
+    #[arg(short, long, value_name = "FILE", default_value = "gateway_config.yaml")]
     pub config: PathBuf,
 }

--- a/src/utils/hot_reload.rs
+++ b/src/utils/hot_reload.rs
@@ -81,10 +81,7 @@ pub async fn watch_config_files(
                     info!("Successfully reloaded gateway_config.yaml");
                 }
                 Err(e) => {
-                    error!(
-                        "Failed to reload gateway_config.yaml: {}. Keeping old config.",
-                        e
-                    );
+                    error!("Failed to reload gateway_config.yaml: {}. Keeping old config.", e);
                 }
             }
         }

--- a/src/ws_proxy.rs
+++ b/src/ws_proxy.rs
@@ -1,7 +1,7 @@
 use axum::{
     extract::{
-        ws::{Message, WebSocket, WebSocketUpgrade},
         Path, State,
+        ws::{Message, WebSocket, WebSocketUpgrade},
     },
     response::Response,
 };

--- a/tests/config_improvements_test.rs
+++ b/tests/config_improvements_test.rs
@@ -2,16 +2,19 @@ use rustway::config::GatewayConfig;
 
 fn parse_config(yaml: &str) -> GatewayConfig {
     let interpolated = rustway::config::interpolate_env_vars_pub(yaml);
-    serde_yaml::from_str(&interpolated).map(|mut cfg: GatewayConfig| {
-        cfg.resolve_services_pub();
-        cfg.apply_defaults_pub();
-        cfg
-    }).unwrap()
+    serde_yaml::from_str(&interpolated)
+        .map(|mut cfg: GatewayConfig| {
+            cfg.resolve_services_pub();
+            cfg.apply_defaults_pub();
+            cfg
+        })
+        .unwrap()
 }
 
 #[test]
 fn test_service_abstraction_resolves_urls() {
-    let cfg = parse_config(r#"
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:8094"
 services:
@@ -26,7 +29,8 @@ routes:
     service: users
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     let route = &cfg.routes[0];
     assert_eq!(route.destinations, vec!["http://users-1:8091", "http://users-2:8091"]);
     assert_eq!(route.timeout.as_ref().unwrap(), "5s");
@@ -35,7 +39,8 @@ identity:
 
 #[test]
 fn test_service_single_url() {
-    let cfg = parse_config(r#"
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:8094"
 services:
@@ -47,13 +52,15 @@ routes:
     service: payments
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     assert_eq!(cfg.routes[0].destination, "http://payments:8080");
 }
 
 #[test]
 fn test_route_overrides_service() {
-    let cfg = parse_config(r#"
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:8094"
 services:
@@ -67,14 +74,16 @@ routes:
     timeout: 10s
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     // Route timeout should override service timeout
     assert_eq!(cfg.routes[0].timeout.as_ref().unwrap(), "10s");
 }
 
 #[test]
 fn test_global_defaults_applied() {
-    let cfg = parse_config(r#"
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:8094"
 defaults:
@@ -88,14 +97,16 @@ routes:
     destination: http://localhost:8080
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     assert_eq!(cfg.routes[0].timeout.as_ref().unwrap(), "3s");
     assert_eq!(cfg.routes[0].retry.as_ref().unwrap().count, 1);
 }
 
 #[test]
 fn test_route_overrides_defaults() {
-    let cfg = parse_config(r#"
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:8094"
 defaults:
@@ -107,33 +118,42 @@ routes:
     timeout: 15s
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     assert_eq!(cfg.routes[0].timeout.as_ref().unwrap(), "15s");
 }
 
 #[test]
 fn test_env_var_interpolation() {
-    unsafe { std::env::set_var("TEST_GW_PORT", "9999"); }
-    let cfg = parse_config(r#"
+    unsafe {
+        std::env::set_var("TEST_GW_PORT", "9999");
+    }
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:${TEST_GW_PORT}"
 routes: []
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     assert_eq!(cfg.server.addr, "0.0.0.0:9999");
-    unsafe { std::env::remove_var("TEST_GW_PORT"); }
+    unsafe {
+        std::env::remove_var("TEST_GW_PORT");
+    }
 }
 
 #[test]
 fn test_env_var_missing_keeps_placeholder() {
-    let cfg = parse_config(r#"
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:${NONEXISTENT_VAR_XYZ}"
 routes: []
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     assert_eq!(cfg.server.addr, "0.0.0.0:${NONEXISTENT_VAR_XYZ}");
 }
 

--- a/tests/config_v2_test.rs
+++ b/tests/config_v2_test.rs
@@ -6,7 +6,8 @@ fn parse_config(yaml: &str) -> GatewayConfig {
 
 #[test]
 fn test_route_single_destination() {
-    let cfg = parse_config(r#"
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:8094"
 routes:
@@ -15,14 +16,16 @@ routes:
     destination: http://localhost:8080
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     let route = &cfg.routes[0];
     assert_eq!(route.all_destinations(), vec!["http://localhost:8080"]);
 }
 
 #[test]
 fn test_route_multiple_destinations() {
-    let cfg = parse_config(r#"
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:8094"
 routes:
@@ -34,7 +37,8 @@ routes:
       - http://svc2:8080
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     let route = &cfg.routes[0];
     let dests = route.all_destinations();
     assert_eq!(dests.len(), 2);
@@ -44,7 +48,8 @@ identity:
 
 #[test]
 fn test_route_load_balance_default() {
-    let cfg = parse_config(r#"
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:8094"
 routes:
@@ -53,17 +58,19 @@ routes:
     destination: http://localhost:8080
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     // Default should be RoundRobin
     match cfg.routes[0].load_balance {
-        rustway::features::load_balancer::LoadBalanceStrategy::RoundRobin => {},
+        rustway::features::load_balancer::LoadBalanceStrategy::RoundRobin => {}
         _ => panic!("Expected RoundRobin default"),
     }
 }
 
 #[test]
 fn test_route_retry_config() {
-    let cfg = parse_config(r#"
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:8094"
 routes:
@@ -76,7 +83,8 @@ routes:
       retry_on: [502, 503]
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     let retry = cfg.routes[0].retry.as_ref().unwrap();
     assert_eq!(retry.count, 3);
     assert_eq!(retry.backoff, "200ms");
@@ -85,7 +93,8 @@ identity:
 
 #[test]
 fn test_route_timeout_config() {
-    let cfg = parse_config(r#"
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:8094"
 routes:
@@ -95,13 +104,15 @@ routes:
     timeout: 5s
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     assert_eq!(cfg.routes[0].timeout.as_ref().unwrap(), "5s");
 }
 
 #[test]
 fn test_route_transform_config() {
-    let cfg = parse_config(r#"
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:8094"
 routes:
@@ -118,7 +129,8 @@ routes:
       remove_response_headers: [server]
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     let t = cfg.routes[0].transform.as_ref().unwrap();
     assert_eq!(t.rewrite_path.as_ref().unwrap(), "/v2{path}");
     assert_eq!(t.request_headers.get("x-custom").unwrap(), "value");
@@ -129,7 +141,8 @@ identity:
 
 #[test]
 fn test_route_health_check_config() {
-    let cfg = parse_config(r#"
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:8094"
 routes:
@@ -141,7 +154,8 @@ routes:
       path: /healthz
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     let hc = cfg.routes[0].health_check.as_ref().unwrap();
     assert_eq!(hc.interval, "10s");
     assert_eq!(hc.path, "/healthz");
@@ -149,7 +163,8 @@ identity:
 
 #[test]
 fn test_route_tls_skip_verify() {
-    let cfg = parse_config(r#"
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:8094"
 routes:
@@ -159,13 +174,15 @@ routes:
     tls_skip_verify: true
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     assert!(cfg.routes[0].tls_skip_verify);
 }
 
 #[test]
 fn test_route_aggregate_config() {
-    let cfg = parse_config(r#"
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:8094"
 routes:
@@ -182,7 +199,8 @@ routes:
         field: orders
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     let agg = cfg.routes[0].aggregate.as_ref().unwrap();
     assert_eq!(agg.len(), 2);
     assert_eq!(agg[0].field, "user");
@@ -192,7 +210,8 @@ identity:
 
 #[test]
 fn test_cors_config() {
-    let cfg = parse_config(r#"
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:8094"
 routes: []
@@ -202,7 +221,8 @@ cors:
   methods: [GET, POST]
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     assert!(cfg.cors.enabled);
     assert_eq!(cfg.cors.origins.len(), 2);
     assert_eq!(cfg.cors.methods, vec!["GET", "POST"]);
@@ -210,19 +230,22 @@ identity:
 
 #[test]
 fn test_cors_disabled_by_default() {
-    let cfg = parse_config(r#"
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:8094"
 routes: []
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     assert!(!cfg.cors.enabled);
 }
 
 #[test]
 fn test_pool_config() {
-    let cfg = parse_config(r#"
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:8094"
   pool:
@@ -234,7 +257,8 @@ server:
 routes: []
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     assert_eq!(cfg.server.pool.idle_timeout, "120s");
     assert_eq!(cfg.server.pool.max_idle_per_host, 64);
     assert_eq!(cfg.server.pool.connect_timeout, "3s");
@@ -244,13 +268,15 @@ identity:
 
 #[test]
 fn test_pool_config_defaults() {
-    let cfg = parse_config(r#"
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:8094"
 routes: []
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     assert_eq!(cfg.server.pool.idle_timeout, "90s");
     assert_eq!(cfg.server.pool.max_idle_per_host, 32);
     assert_eq!(cfg.server.pool.body_limit, "10mb");
@@ -258,7 +284,8 @@ identity:
 
 #[test]
 fn test_find_route_longest_match() {
-    let cfg = parse_config(r#"
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:8094"
 routes:
@@ -270,14 +297,16 @@ routes:
     destination: http://users:8080
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     let route = cfg.find_route_for_path("/api/users/123").unwrap();
     assert_eq!(route.name, "specific");
 }
 
 #[test]
 fn test_find_route_no_match() {
-    let cfg = parse_config(r#"
+    let cfg = parse_config(
+        r#"
 server:
   addr: "0.0.0.0:8094"
 routes:
@@ -286,6 +315,7 @@ routes:
     destination: http://localhost:8080
 identity:
   api_key_store_path: ./api_keys.yaml
-"#);
+"#,
+    );
     assert!(cfg.find_route_for_path("/other").is_none());
 }

--- a/tests/load_balancer_test.rs
+++ b/tests/load_balancer_test.rs
@@ -3,21 +3,27 @@ use rustway::features::load_balancer::{LoadBalanceStrategy, LoadBalancer};
 #[test]
 fn test_round_robin_distribution() {
     let lb = LoadBalancer::new();
-    let results: Vec<usize> = (0..6).map(|_| lb.next_index(3, &LoadBalanceStrategy::RoundRobin).unwrap()).collect();
+    let results: Vec<usize> = (0..6)
+        .map(|_| lb.next_index(3, &LoadBalanceStrategy::RoundRobin).unwrap())
+        .collect();
     assert_eq!(results, vec![0, 1, 2, 0, 1, 2]);
 }
 
 #[test]
 fn test_round_robin_two_backends() {
     let lb = LoadBalancer::new();
-    let results: Vec<usize> = (0..4).map(|_| lb.next_index(2, &LoadBalanceStrategy::RoundRobin).unwrap()).collect();
+    let results: Vec<usize> = (0..4)
+        .map(|_| lb.next_index(2, &LoadBalanceStrategy::RoundRobin).unwrap())
+        .collect();
     assert_eq!(results, vec![0, 1, 0, 1]);
 }
 
 #[test]
 fn test_round_robin_single_backend() {
     let lb = LoadBalancer::new();
-    let results: Vec<usize> = (0..5).map(|_| lb.next_index(1, &LoadBalanceStrategy::RoundRobin).unwrap()).collect();
+    let results: Vec<usize> = (0..5)
+        .map(|_| lb.next_index(1, &LoadBalanceStrategy::RoundRobin).unwrap())
+        .collect();
     assert_eq!(results, vec![0, 0, 0, 0, 0]);
 }
 


### PR DESCRIPTION
## Changes

- Add clippy lints to Cargo.toml (pedantic, unwrap/expect/panic warn)
- Create rustfmt.toml (edition 2024, max_width 120)
- Fix clippy errors (collapsible if, type complexity)
- Apply rustfmt to all source files
- Create .markdownlint.yaml config
- Fix all markdown files to pass markdownlint

## Verification

- `cargo clippy` — 0 errors, 62 pedantic warnings (existing code)
- `cargo fmt --check` — clean
- `cargo test` — 66 tests passing
- `cargo audit` — 0 vulnerabilities
- `markdownlint` — all .md files pass

Ref #72